### PR TITLE
feat: Fix typos and add backticks

### DIFF
--- a/lab9/instructions.ipynb
+++ b/lab9/instructions.ipynb
@@ -88,7 +88,7 @@
     "We will use a simple feedforward neural network with:\n",
     "\n",
     "Input layer: 2 neurons (for our 2D data) <br>\n",
-    "Hidden layer: N_HIDDEN neurons with tanh activation. You can start with `N_HIDDEN=32` <br>\n",
+    "Hidden layer: `N_HIDDEN_NODES` neurons with tanh activation. You can start with `N_HIDDEN_NODES=32` <br>\n",
     "Output layer: 1 neuron with sigmoid activation (for binary classification probability) <br>\n",
     "The parameters (weights and biases) of this network will be flattened into a single vector for CMA-ES to optimize."
    ]
@@ -211,7 +211,7 @@
    "metadata": {},
    "source": [
     "### 5. Training with a Standard Gradient-Based Method\n",
-    "Now, let's train a neural network with the same architecture using a standard gradient-based optimizer. You can use `scikit-learn`'s MLPClassifier, which employs optimizers like 'adam' or 'sgd' and uses a differentiable loss function (like cross-entropy) internally. Display decision boundary for a trained model."
+    "Now, let's train a neural network with the same architecture using a standard gradient-based optimizer. You can use `scikit-learn`'s `MLPClassifier`, which employs optimizers like 'adam' or 'sgd' and uses a differentiable loss function (like cross-entropy) internally. Display decision boundary for a trained model."
    ]
   },
   {
@@ -236,7 +236,7 @@
    "source": [
     "### Exercise 2\n",
     "\n",
-    "Improve the hyperparameters of the MLPClassifier, with particular attention to the learning rate, the maximum number of iterations, and other relevant training parameters. Your objective is to achieve performance that surpasses that of the CMA-ES baseline."
+    "Improve the hyperparameters of the `MLPClassifier`, with particular attention to the learning rate, the maximum number of iterations, and other relevant training parameters. Your objective is to achieve performance that surpasses that of the CMA-ES baseline."
    ]
   },
   {


### PR DESCRIPTION
# Description
There's a single typo in the Jupyter Notebook text where `N_HIDDEN_NODES` is called `N_HIDDEN` and backticks are omitted. This PR fixes the typo.

*It's a really good notebook* 😊